### PR TITLE
use custom header name

### DIFF
--- a/stklog.js
+++ b/stklog.js
@@ -68,7 +68,7 @@
             done(null, xhttp.response);
         };
         xhttp.setRequestHeader("Content-Type", "application/json");
-        xhttp.setRequestHeader("Stklog-Project-Key", project_key);
+        xhttp.setRequestHeader("X-Stklog-Project-Key", project_key);
         xhttp.send(JSON.stringify(array));
     }
 


### PR DESCRIPTION
Custom header should be written with the "X-" prefix, it's a common practice that insure good logs readability when needed to debug...

this would require a change in your api too !

pr on logrus hook incoming 